### PR TITLE
Replace 'UTF-8' with `encoding` variable

### DIFF
--- a/groovy-src/main/lt/groovy/ScriptExecutor.groovy
+++ b/groovy-src/main/lt/groovy/ScriptExecutor.groovy
@@ -13,7 +13,7 @@ class ScriptExecutor {
 
         def encoding = 'UTF-8'
         def stream = new ByteArrayOutputStream()
-        def printStream = new PrintStream(stream, true, 'UTF-8')
+        def printStream = new PrintStream(stream, true, encoding)
 
         def stacktrace = new StringWriter()
         def errWriter = new PrintWriter(stacktrace)


### PR DESCRIPTION
This does literally _nothing_ different or useful, but I've been trying my hand at writing a plugin--with this source as a reference--and it's been bothering me all day. ;)
